### PR TITLE
Include building against JDK 13 in build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ matrix:
       jdk: openjdk11
     - dist: xenial
       jdk: openjdk12
-#    - dist: xenial
-#      jdk: openjdk13
+    - dist: xenial
+      jdk: openjdk13
 

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,15 @@ allprojects {
         jcenter()
     }
 
+    configurations.all {
+        resolutionStrategy {
+            dependencySubstitution {
+                // workaround for spotbugs not yet supporting JDK 13 class formats
+                substitute module('org.ow2.asm:asm')  with module ("org.ow2.asm:asm:${versionAsm}")
+            }
+        }
+    }
+
     // configuring Spotless
     apply plugin: "com.diffplug.gradle.spotless"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,6 +28,7 @@ currentVersion=1.0-SNAPSHOT
 executeCFPClientLiveTests=false
 
 # artifact versions
+versionAsm=7.2
 versionAssertJ=3.+
 versionErrorProneCore=2.3.3
 versionGradleErrorpronePlugin4Java11AndLater=1.1.1


### PR DESCRIPTION
fixes TweetWallFX/TweetwallFX-Devoxx-2019-BE#76